### PR TITLE
pin puppet-lint correctly

### DIFF
--- a/puppet-lint-variable_contains_upcase.gemspec
+++ b/puppet-lint-variable_contains_upcase.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 0'
 end

--- a/puppet-lint-variable_contains_upcase.gemspec
+++ b/puppet-lint-variable_contains_upcase.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     Extends puppet-lint to ensure that your variables are all lower case
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
needed since puppet-lint 2.0.0 got release lately