### PR TITLE
Allow use with puppet-lint v2

### DIFF
--- a/puppet-lint-variable_contains_upcase.gemspec
+++ b/puppet-lint-variable_contains_upcase.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     Extends puppet-lint to ensure that your variables are all lower case
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
Puppet-lint v2 has now been released, and works fine with puppet-lint-variable_contains_upcase (we've been using PLVCU with puppet-lint HEAD in OpenStack without problems). Update the dependency specifier in the gemspec, so users can continue to use PLVCU with the latest release of puppet-lint.

The dependency on puppet-lint 1.x has been causing us spurious CI breakages (see eg [here](http://logs.openstack.org/55/324555/5/check/gate-instack-undercloud-puppet-lint/bde5553/console.html.gz#_2016-06-30_16_55_55_373420)), so it would be great if this could be merged.
