### PR TITLE
get rid of VARIABLE_TYPES

### DIFF
--- a/lib/puppet-lint/plugins/variable_contains_upcase.rb
+++ b/lib/puppet-lint/plugins/variable_contains_upcase.rb
@@ -1,7 +1,7 @@
 PuppetLint.new_check(:variable_contains_upcase) do
   def check
     tokens.select { |r|
-      VARIABLE_TYPES.include? r.type
+      Set[:VARIABLE, :UNENC_VARIABLE].include? r.type
     }.each do |token|
       if token.value.match(/[A-Z]/)
         notify :warning, {


### PR DESCRIPTION
it was removed/renamed in
https://github.com/rodjek/puppet-lint/pull/483/ which is now in
puppet-lint 2.0.1