### PR TITLE
Added fix functionality

### DIFF
--- a/lib/puppet-lint/plugins/variable_contains_upcase.rb
+++ b/lib/puppet-lint/plugins/variable_contains_upcase.rb
@@ -8,8 +8,12 @@ PuppetLint.new_check(:variable_contains_upcase) do
           :message => 'variable contains a capital letter',
           :line    => token.line,
           :column  => token.column,
+          :token   => token,
         }
       end
     end
+  end
+  def fix(problem)
+    problem[:token].value.downcase!
   end
 end

--- a/test/readme
+++ b/test/readme
@@ -1,0 +1,6 @@
+To test the fix functionality of this plugin, open a terminal in this folder and run:
+
+puppet-lint --only-checks variable_contains_upcase --fix test.pp
+
+The test should find uppercases in variables on lines 1 and 3.  Examining test.pp after
+running the test should show that the variable $FileName has been changed to $filename.

--- a/test/test.pp
+++ b/test/test.pp
@@ -1,0 +1,6 @@
+$FilnName = '/home/seth/Dev/Puppet/puppetlint-plugins/test-proj/test.txt'
+$content = 'helloworld'
+file { $FileName:
+  ensure  => file,
+  content => $content,
+}

--- a/test/test~.pp
+++ b/test/test~.pp
@@ -1,0 +1,6 @@
+$FilnName = '/home/seth/Dev/Puppet/puppetlint-plugins/test-proj/test.txt'
+$content = 'helloworld'
+file { $FileName:
+  ensure  => file,
+  content => $content,
+}


### PR DESCRIPTION
I had to update from Puppet 3 to Puppet 4 and this plug-in found hundreds of cases that would cause failures in Puppet 3 when using Future Parser.  The fix function just lower cases all variable names.