### PR TITLE
puppet-lint: Allow 4.x

### DIFF
--- a/puppet-lint-variable_contains_upcase.gemspec
+++ b/puppet-lint-variable_contains_upcase.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     Extends puppet-lint to ensure that your variables are all lower case
   EOF
 
-  spec.add_dependency             'puppet-lint', '>= 1.0', '< 4'
+  spec.add_dependency             'puppet-lint', '>= 1.0', '< 5'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
Hey @fiddyspence , could you please merge and release this shortly? Are you interested in migrating the plugin to Vox Pupuli, so more people could do maintenance on it (like proper CI config, ruboocop)? Of course you would keep merge access. Vox Pupuli is a collective that currently maintains all important puppet-lint plugins.